### PR TITLE
deviseの画面遷移後のフラッシュメッセージ表示を実装した。

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -8,7 +8,7 @@ class ChatsController < ApplicationController
     if @message.save
       redirect_to action: "index"
     else
-      flash[:notice] = "メッセージを入力してください"
+      flash[:alert] = "メッセージを入力してください"
       redirect_to action: "index"
     end
   end

--- a/app/views/chats/index.html.haml
+++ b/app/views/chats/index.html.haml
@@ -1,15 +1,16 @@
-.layout-notice グループを作成しました
+- if flash[:notice].present?
+  .layout-notice
+    =flash[:notice]
 
-- if flash.present?
+- if flash[:alert].present?
   .error_message
-    - flash.each do |key, value|
-      = content_tag(:div, value, class: "#{key}")
+    =flash[:alert]
 
 .chat
   .chat__side
     .chat__side--user
       %h5 Hello!
-      %a{ href:"/users/edit", class:"edit-user-registration"}
+      = link_to edit_user_registration_path, class: "edit-user-registration" do
         %i.fa.fa-cog
       %a.create-a-chat-group
         %i.fa.fa-pencil-square-o


### PR DESCRIPTION
#WHAT
deviseの画面遷移後のフラッシュメッセージの実装。
メッセージ未入力でsubmitボタンを押した時のエラーメッセージ（メッセージを入力してください）をこのメッセージと区別するためにflashのキーをnoticeとvalueで分けた。

link_toタグで書き直すのを忘れてしまったのでここのコミットと同じにしています

#WHY
フラッシュメッセージ実装のため。